### PR TITLE
fix: allow login-by-code redemption for SSO and social logins (#83)

### DIFF
--- a/api/src/tv-modules/auth/AuthRoutes.ts
+++ b/api/src/tv-modules/auth/AuthRoutes.ts
@@ -3,7 +3,7 @@ import type { Routable } from '../../types/routable.type';
 import AuthController from './AuthController';
 import { IsLoggedIn } from './middlewares/is-logged-in';
 import { RejectApiTokenAuth } from '../api-tokens/middlewares/RejectApiTokenAuth';
-import { RequireLoginMethod, RequireSocialProvider } from './middlewares/require-login-method';
+import { RequireAnyLoginMethod, RequireLoginMethod, RequireSocialProvider } from './middlewares/require-login-method';
 import passport from './strategies/passport-login';
 import { ExternalProviderScope } from './strategies/external-auth.types';
 export default class AuthRoutes implements Routable {
@@ -23,7 +23,9 @@ export default class AuthRoutes implements Routable {
     initRoutes() {
         this.router.get('/login-options', this.authController.getLoginOptions);
         this.router.post('/send-login-code', [RequireLoginMethod('magic-link')], this.authController.sendLoginCode);
-        this.router.post('/login-by-code', [RequireLoginMethod('magic-link')], this.authController.loginByCode);
+        // Shared one-time-code redemption: magic-link emails, SSO callbacks and social
+        // OAuth callbacks all complete the login through this endpoint
+        this.router.post('/login-by-code', [RequireAnyLoginMethod(['magic-link', 'sso', 'social'])], this.authController.loginByCode);
         this.router.post('/login', [RequireLoginMethod('password')], this.authController.login);
         this.router.post('/registration', this.authController.registration);
         this.router.get('/confirm/email/:code/login/:login', this.authController.confirmEmail);

--- a/api/src/tv-modules/auth/middlewares/require-login-method.ts
+++ b/api/src/tv-modules/auth/middlewares/require-login-method.ts
@@ -11,6 +11,15 @@ export const RequireLoginMethod = (method: LoginMethod) => {
     };
 };
 
+export const RequireAnyLoginMethod = (methods: LoginMethod[]) => {
+    return (_req: Request, res: Response, next: NextFunction) => {
+        if (!methods.some((method) => LoginMethods.isEnabled(method))) {
+            return res.status(403).send();
+        }
+        return next();
+    };
+};
+
 export const RequireSocialProvider = (req: Request, res: Response, next: NextFunction) => {
     const providerName = String(req.params.providerName || '').toLowerCase();
     if (!LoginMethods.availableSocialProviders().includes(providerName)) {

--- a/web/src/pages/login.vue
+++ b/web/src/pages/login.vue
@@ -75,6 +75,11 @@ onMounted(async () => {
     await loginByCode(result.code, result.email)
   } catch (error) {
     console.error('Failed to process tokens from URL:', error)
+    toast.add({
+      title: t('auth.error'),
+      description: t('auth.loginFailed'),
+      color: 'error',
+    })
   }
 })
 
@@ -92,6 +97,11 @@ App.addListener('appUrlOpen', async ({ url }) => {
       await loginByCode(result.code, result.email)
     } catch (error) {
       console.error('Failed to process deep link tokens:', error)
+      toast.add({
+        title: t('auth.error'),
+        description: t('auth.loginFailed'),
+        color: 'error',
+      })
     }
   }
 


### PR DESCRIPTION
SSO and social OAuth callbacks complete the login by redeeming a one-time code through POST /module/auth/login-by-code, but the endpoint was gated behind RequireLoginMethod('magic-link'). With AUTH_LOGIN_METHODS excluding magic-link (e.g. "sso"), the redemption returned an empty 403 and the user silently bounced back to the login page.

- Add RequireAnyLoginMethod and gate /login-by-code on magic-link OR sso OR social
- Show a toast on failed code redemption instead of only logging to console

Issue: https://github.com/Gimanh/taskview-community/issues/83 